### PR TITLE
Fix duplicated /incoming in shareddir.conf when MOD_AUTO_SHARE_ENABLED is used

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ mod_auto_share() {
         # Share all the directories (separated by semicolon ';') and subdirectories in aMule.
         printf "[MOD_AUTO_SHARE] Sharing the following directories with sub-directories: %s ... You can disable this mod with MOD_AUTO_SHARE_ENABLED=false\n" "$MOD_AUTO_SHARE_DIRECTORIES"
         SHAREDDIR_CONF=${AMULE_HOME}/shareddir.dat
-        printf "/incoming\n" > "$SHAREDDIR_CONF"
+        > "$SHAREDDIR_CONF"
         iter=""
         IN="$MOD_AUTO_SHARE_DIRECTORIES"
         while [ "$IN" != "$iter" ] ;do
@@ -63,6 +63,9 @@ mod_auto_share() {
             printf "[MOD_AUTO_SHARE] Sharing directory '%s' with sub-directories...\n" "$iter"
             find "$iter" -type d >> "$SHAREDDIR_CONF"
         done
+        if ! grep -q "^/incoming$" "$SHAREDDIR_CONF" ; then
+            printf "/incoming\n" >> "$SHAREDDIR_CONF"
+        fi
     fi
 }
 


### PR DESCRIPTION
Refactored mod_auto_share function to avoid duplicated entries of "/incoming" into shareddir.conf when MOD_AUTO_SHARE_DIRECTORIES is "/incoming" (default value).