### PR TITLE
Added the option to disable the temp and incoming folders chown

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ services:
       - MOD_AUTO_SHARE_DIRECTORIES=/incoming;/my_movies
       - MOD_FIX_KAD_GRAPH_ENABLED=true
       - MOD_FIX_KAD_BOOTSTRAP_ENABLED=true
+      - DISABLE_INCOMING_CHOWN=false
+      - DISABLE_TEMP_CHOWN=false
     ports:
       - "4711:4711" # web ui
       - "4712:4712" # remote gui, webserver, cmd ...
@@ -108,6 +110,8 @@ docker run -d \
   -e MOD_AUTO_SHARE_DIRECTORIES=/incoming;/my_movies `#optional` \
   -e MOD_FIX_KAD_GRAPH_ENABLED=true `#optional` \
   -e MOD_FIX_KAD_BOOTSTRAP_ENABLED=true `#optional` \
+  -e DISABLE_INCOMING_CHOWN=false `#optional` \
+  -e DISABLE_TEMP_CHOWN=false `#optional` \
   -v <fill_amule_configuration_path>:/home/amule/.aMule \
   -v <fill_amule_completed_downloads_path>:/incoming \
   -v <fill_amule_incomplete_downloads_path>:/temp \
@@ -137,6 +141,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e MOD_AUTO_SHARE_DIRECTORIES=/incoming;/my_movies` | aMule auto share directories with subdirectories. Check modifications section. |
 | `-e MOD_FIX_KAD_GRAPH_ENABLED=true` | Fix Kad stats graph bug. Check modifications section. |
 | `-e MOD_FIX_KAD_BOOTSTRAP_ENABLED=true` | Fix Kad bootstrap bug. Check modifications section. |
+| `-e DISABLE_INCOMING_CHOWN=false` | Disable the /incoming folder chown at boot. Useful when the ownership cannot be changed. |
+| `-e DISABLE_TEMP_CHOWN=false` | Disable the /temp folder chown at boot. Useful when the ownership cannot be changed. |
 | `-v /home/amule/.aMule` | Path to save aMule configuration. |
 | `-v /incoming` | Path to completed torrents. |
 | `-v /temp` | Path to incomplete torrents. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - MOD_AUTO_SHARE_DIRECTORIES=/incoming;/my_movies
       - MOD_FIX_KAD_GRAPH_ENABLED=true
       - MOD_FIX_KAD_BOOTSTRAP_ENABLED=true
+      - DISABLE_INCOMING_CHOWN=false
+      - DISABLE_TEMP_CHOWN=false
     ports:
       - "4711:4711" # web ui
       - "4712:4712" # remote gui, webserver, cmd ...

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -364,8 +364,12 @@ if [ -n "${WEBUI_PWD}" ]; then
 fi
 
 # Set permissions
-chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_INCOMING}"
-chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_TEMP}"
+if [ "${DISABLE_INCOMING_CHOWN:-false}" == "false" ]; then
+    chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_INCOMING}"
+fi
+if [ "${DISABLE_TEMP_CHOWN:-false}" == "false" ]; then
+    chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_TEMP}"
+fi
 chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_HOME}"
 
 # Modifications / Fixes


### PR DESCRIPTION
Hello,

This PR justs adds an option to disable the temp and incoming folders chown using env variables. They are very convenient in local environments but can be a problem when using network drives. For example on my setup I am using Kubernetes and a NFS share mounted by a PVC. The chown of those folders was causing the pod to crash, not allowing to boot the application.

Best regards.