### PR TITLE
Fix MOD_AUTO_SHARE "Permission denied" errors on shareddir-recursive.dat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix MOD_AUTO_SHARE "error 13: Permission denied" log errors on shareddir-recursive.dat. The file is no longer made read-only: aMule is patched (patches/001-no-shareddir-write-before-load.patch) so it does not wipe pre-seeded shareddir*.dat files on the very first run, and it can now persist auto-shared sub-directories and WebUI/remote share changes
+
 ## 3.0.0-1 (2026/06/09)
 
 * **Major release:** Please read this changelog carefully before upgrading. It is strongly recommended to back up your aMule config folder and to create new `amule.conf` and `remote.conf` files with default values.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Build aMule from source (AMULE_REF can be a tag, branch, or commit SHA)
 ARG AMULE_REF=3.0.0
+COPY patches /tmp/patches
 RUN git init -q amule-src && \
     git -C amule-src fetch --depth 1 --tags https://github.com/amule-org/amule.git ${AMULE_REF} && \
     git -C amule-src checkout -q FETCH_HEAD && \
+    # Apply downstream patches not yet merged upstream (see patches/*.patch headers)
+    git -C amule-src apply --verbose /tmp/patches/*.patch && \
     # libatomic1 only ships libatomic.so.1; find_library(atomic) needs the unversioned symlink
     so="$(find /usr/lib -name 'libatomic.so.1' -print -quit)" && [ -n "$so" ] && ln -sf "$(basename "$so")" "${so%.1}" ; \
     cmake -B amule-build amule-src \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -15,9 +15,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Built with CMAKE_BUILD_TYPE=Debug so the binaries keep full debug symbols and are
 # not optimized, making them suitable for gdb / heaptrack analysis
 ARG AMULE_REF=master
+COPY patches /tmp/patches
 RUN git init -q amule-src && \
     git -C amule-src fetch --depth 1 --tags https://github.com/amule-org/amule.git ${AMULE_REF} && \
     git -C amule-src checkout -q FETCH_HEAD && \
+    # Apply downstream patches not yet merged upstream (see patches/*.patch headers)
+    git -C amule-src apply --verbose /tmp/patches/*.patch && \
     # libatomic1 only ships libatomic.so.1; find_library(atomic) needs the unversioned symlink
     so="$(find /usr/lib -name 'libatomic.so.1' -print -quit)" && [ -n "$so" ] && ln -sf "$(basename "$so")" "${so%.1}" ; \
     cmake -B amule-build amule-src \

--- a/docker/amule-mods.sh
+++ b/docker/amule-mods.sh
@@ -49,9 +49,10 @@ mod_auto_share() {
         # so aMule regenerates it from the recursive roots.
         rm -f "${AMULE_HOME}/shareddir.dat"
         chown "${AMULE_USER}:${AMULE_GROUP}" "$SHAREDDIR_CONF"
-        # Read-only: on the very first run aMule rewrites the shared-dir files (empty) while
-        # persisting its initial preferences, before loading them. Keeping this file read-only
-        # prevents that wipe, so aMule reads our recursive roots and regenerates shareddir.dat.
-        chmod 444 "$SHAREDDIR_CONF"
+        # Writable by aMule: it rewrites this file to persist auto-shared sub-directories and
+        # WebUI/remote changes. aMule no longer wipes it before loading on the very first run
+        # (see patches/001-no-shareddir-write-before-load.patch). This also restores write
+        # permissions on volumes created by older image versions, which used chmod 444 here.
+        chmod 644 "$SHAREDDIR_CONF"
     fi
 }

--- a/patches/001-no-shareddir-write-before-load.patch
+++ b/patches/001-no-shareddir-write-before-load.patch
@@ -1,0 +1,67 @@
+Fix first-run wipe of pre-seeded shareddir*.dat files
+
+On the very first start (no preferences.dat yet) CPreferences's
+constructor calls Save() to persist the freshly generated userhash.
+Save() -> SaveSharedFolders() then writes the three shareddir*.dat
+files from the in-memory lists, which are still empty because
+ReloadSharedFolders() only runs afterwards. This wipes any
+shareddir-recursive.dat pre-seeded by an external script (e.g. this
+image's MOD_AUTO_SHARE entrypoint) before aMule ever reads it.
+
+The previous workaround (chmod 444 on the pre-seeded file) blocked the
+wipe but made every later legitimate SaveSharedFolders() fail with
+"error 13: Permission denied" (startup reconciliation, the shared-dir
+watcher persisting auto-added subdirectories, EC/WebUI saves).
+
+Fix: SaveSharedFolders() is a no-op until ReloadSharedFolders() has
+loaded the on-disk files once.
+
+Applies to amule-org/amule d6e3cdca69d42a8db0ae6790dfb6a92133f41a2e.
+Drop this patch once the fix lands upstream.
+
+diff --git a/src/Preferences.cpp b/src/Preferences.cpp
+index 31b33ac42..ad95d311f 100644
+--- a/src/Preferences.cpp
++++ b/src/Preferences.cpp
+@@ -1538,6 +1538,14 @@ void CPreferences::Save()
+ void CPreferences::SaveSharedFolders()
+ {
+ 	#ifndef CLIENT_GUI
++	// Never write before ReloadSharedFolders() has loaded the on-disk
++	// files: the constructor's first-run Save() (persisting the freshly
++	// generated userhash) happens before they are loaded, and writing
++	// the still-empty lists would wipe shareddir*.dat files pre-seeded
++	// by external scripts (e.g. Docker entrypoints).
++	if (!m_sharedFoldersLoaded) {
++		return;
++	}
+ 	// Canonical sources of truth: shareddir-explicit.dat (user-added
+ 	// non-recursive roots) and shareddir-recursive.dat (user-marked
+ 	// recursive roots). Older versions of aMule know nothing about
+@@ -2021,6 +2029,7 @@ void CPreferences::ReloadSharedFolders()
+ 	// Persist all three files so a crash mid-session doesn't leave
+ 	// reconciled state un-written, and so the union is up-to-date
+ 	// for any external reader.
++	m_sharedFoldersLoaded = true;
+ 	SaveSharedFolders();
+ #endif
+ }
+diff --git a/src/Preferences.h b/src/Preferences.h
+index 07d2a4f9e..d41f65cbf 100644
+--- a/src/Preferences.h
++++ b/src/Preferences.h
+@@ -403,6 +403,14 @@ public:
+ 	// intent in this file.
+ 	PathList shareddir_recursive_list;
+ 
++	// False until ReloadSharedFolders() has loaded the on-disk
++	// shareddir*.dat files once. SaveSharedFolders() is a no-op while
++	// false: the constructor's first-run Save() (persisting the freshly
++	// generated userhash) runs before the lists are loaded and would
++	// otherwise overwrite files pre-seeded by external scripts (e.g.
++	// Docker entrypoints) with empty ones.
++	bool m_sharedFoldersLoaded = false;
++
+ 	wxArrayString addresses_list;
+ 
+ 	static bool		AutoConnectStaticOnly()		{ return s_autoconnectstaticonly; }


### PR DESCRIPTION
With MOD_AUTO_SHARE_ENABLED=true the container log was flooded with:

  Error: can't open file '/home/amule/.aMule/shareddir-recursive.dat'
  (error 13: Permission denied)

Root cause (in aMule itself, not in the entrypoint): on the very first start (no preferences.dat yet) CPreferences's constructor calls Save() to persist the freshly generated userhash (src/Preferences.cpp:993). Save() -> SaveSharedFolders() then rewrites the three shareddir*.dat files from the in-memory lists, which are still empty because ReloadSharedFolders() only runs afterwards (src/Preferences.cpp:1003). That wiped the shareddir-recursive.dat pre-seeded by mod_auto_share before aMule ever read it. The previous workaround (chmod 444 on the file) blocked the wipe but made every later legitimate SaveSharedFolders() fail with EACCES: the trailing save in ReloadSharedFolders(), the shared-dir watcher persisting auto-added sub-directories (SharedDirWatcher.cpp), and WebUI/EC share changes. Those failures are the logged errors, and they also meant runtime share changes could never be persisted.

Fix: patch aMule so SaveSharedFolders() is a no-op until ReloadSharedFolders() has loaded the on-disk files once (patches/001-no-shareddir-write-before-load.patch, applied with git apply in both Dockerfiles after the checkout). The chmod 444 in mod_auto_share is replaced with chmod 644, which also restores write permissions on volumes created by older image versions.

Upstream: the patch should be submitted to amule-org/amule. It applies cleanly on both the 3.0.0 tag and current master (d6e3cdca and later). Suggested upstream rationale: external scripts (e.g. Docker entrypoints) pre-seed shareddir*.dat before the first start, and the constructor's first-run Save() must not overwrite files it has not loaded yet. Drop the patch and bump AMULE_REF once it lands.

Verified by building the image and running it against a live container:

1. First start with a fresh config volume: zero permission errors, shareddir-recursive.dat keeps its pre-seeded roots (no longer wiped), shareddir.dat regenerated as the recursive expansion (roots plus existing sub-directories), files owned by amule with mode 644.
2. Hot auto-add: creating a new sub-directory under a recursive root while amuled runs is picked up by the shared-dir watcher and persisted to shareddir.dat without errors (this always failed with chmod 444).
3. Container restart with existing config: clean logs, files intact, all sub-directories still shared.
4. Upgrade path: a volume with the old read-only (444) file is regenerated with mode 644 by the entrypoint and works normally.
5. MOD_AUTO_SHARE_ENABLED=false with a fresh volume: no errors; aMule generates its own (empty) shareddir*.dat files normally, since the guard only delays the first write until after ReloadSharedFolders(), which runs on every start.